### PR TITLE
Patch can not run table_list command

### DIFF
--- a/goroo.go
+++ b/goroo.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 )
 
 const (
@@ -267,11 +266,12 @@ func (client *GroongaClient) Call(command string, params map[string]string) (res
 }
 
 func (client *GroongaClient) setResult(body []byte) (result GroongaResult, err error) {
-	result.RawData = fmt.Sprintf("%s", body)
+	result.RawData =string(body)
 
 	var data interface{}
-	dec := json.NewDecoder(strings.NewReader(result.RawData))
-	dec.Decode(&data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return result, err
+	}
 
 	if client.Protocol == "http" {
 		grnInfo := data.([]interface{})

--- a/goroo.go
+++ b/goroo.go
@@ -240,10 +240,6 @@ func (client *GroongaClient) callHTTP(command string, params map[string]string) 
 }
 
 func (client *GroongaClient) Call(command string, params map[string]string) (result GroongaResult, err error) {
-	if len(params) == 0 {
-		return result, nil
-	}
-
 	var body []byte
 	if client.Protocol == "gqtp" {
 		// GQTP
@@ -266,7 +262,7 @@ func (client *GroongaClient) Call(command string, params map[string]string) (res
 }
 
 func (client *GroongaClient) setResult(body []byte) (result GroongaResult, err error) {
-	result.RawData =string(body)
+	result.RawData = string(body)
 
 	var data interface{}
 	if err := json.Unmarshal(body, &data); err != nil {

--- a/goroo_test.go
+++ b/goroo_test.go
@@ -113,6 +113,14 @@ func TestGQTPClient(t *testing.T) {
 	}
 }
 
+func TestEmptyParamerCommand(t *testing.T) {
+	client := NewGroongaClient("http", "localhost", 10041)
+	result, _ := client.Call("table_create", map[string]string{})
+	if len(result.RawData) == 0 {
+		t.Errorf("response body not found")
+	}
+}
+
 // Benchmarks
 func BenchmarkHTTPClient(b *testing.B) {
 	client := NewGroongaClient("http", "localhost", 10041)


### PR DESCRIPTION
**問題点**
table_list コマンドを実行したときにコマンドが実行されず、GroongaResult の初期値が返されてしまう。

**修正概要**
Call 内でparams 数をチェックする処理を削除

**その他**
- []byte の string 変換方法を変更
- json.Unmarshalでjsonの変換実施
